### PR TITLE
Criação de um ID legível para ser exibido ao usuário

### DIFF
--- a/prisma/migrations/20241001220930_create_readable_order_id/migration.sql
+++ b/prisma/migrations/20241001220930_create_readable_order_id/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "order" ADD COLUMN "orderId" VARCHAR(255);

--- a/prisma/migrations/20241012152719_create_readable_order_id/migration.sql
+++ b/prisma/migrations/20241012152719_create_readable_order_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "order" ADD COLUMN     "readableId" VARCHAR(255);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -111,7 +111,7 @@ enum OrderStatus {
 
 model Order {
   id         String   @id @default(uuid())
-  orderId    String?  @db.VarChar(255)
+  readableId    String?  @db.VarChar(255)
   customerId String?  @db.VarChar(255)
   status     OrderStatus   @default(created)
   createdAt  DateTime @default(now()) @map("created_at")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 
-import { OrderStatusEnum } from '../src/core/domain/enums/orderStatusEnum';
-import { PaymentOrderStatusEnum } from '../src/core/domain/enums/paymentOrderEnum';
+import { OrderStatusEnum } from '../src/core/application/enumerations/orderStatusEnum';
+import { PaymentOrderStatusEnum } from '../src/core/application/enumerations/paymentOrderEnum';
 
 const prisma = new PrismaClient();
 
@@ -87,7 +87,7 @@ async function main() {
 	// Criar produtos
 	const [product1, product2, product3] = await Promise.all([
 		prisma.product.upsert({
-			where: { name: 'Coca-Cola' },
+			where: { name: 'Coca-Cola', id: 'f434ca91-75e6-4d26-93ad-31a7e482deba' },
 			update: {},
 			create: {
 				name: 'Coca-Cola',
@@ -99,7 +99,7 @@ async function main() {
 			},
 		}),
 		prisma.product.upsert({
-			where: { name: 'Cheeseburger' },
+			where: { name: 'Cheeseburger', id: '6badf399-fd7b-4364-a916-d92e7f57a30e' },
 			update: {},
 			create: {
 				name: 'Cheeseburger',
@@ -112,7 +112,7 @@ async function main() {
 			},
 		}),
 		prisma.product.upsert({
-			where: { name: 'Milkshake' },
+			where: { name: 'Milkshake', id: '9726bed3-4d16-4b54-8316-0066eab2888e' },
 			update: {},
 			create: {
 				name: 'Milkshake',
@@ -183,6 +183,7 @@ async function main() {
 					connect: { id: customer1.id },
 				},
 				status: OrderStatusEnum.received,
+				readableId: '1',
 			},
 		}),
 		prisma.order.create({
@@ -196,6 +197,7 @@ async function main() {
 					connect: { id: customer2.id },
 				},
 				status: OrderStatusEnum.received,
+				readableId: '2',
 			},
 		}),
 	]);

--- a/src/adapter/driven/infra/orderRepositoryImpl.ts
+++ b/src/adapter/driven/infra/orderRepositoryImpl.ts
@@ -1,5 +1,5 @@
+import { OrderStatusEnum } from '@application/enumerations/orderStatusEnum';
 import logger from '@common/logger';
-import { OrderStatusEnum } from '@domain/enums/orderStatusEnum';
 import { OrderStatusType } from '@domain/types/orderStatusType';
 import { prisma } from '@driven/infra/lib/prisma';
 import { DataNotFoundException } from '@exceptions/dataNotFound';
@@ -150,6 +150,7 @@ export class OrderRepositoryImpl implements OrderRepository {
 				},
 				data: {
 					status: order.status,
+					readableId: order.readableId,
 				},
 			})
 			.catch(() => {
@@ -176,7 +177,7 @@ export class OrderRepositoryImpl implements OrderRepository {
 				status: {
 					notIn: [OrderStatusEnum.created],
 				},
-				orderId: {
+				readableId: {
 					not: null,
 				}
 			},

--- a/src/adapter/driver/routes/index.ts
+++ b/src/adapter/driver/routes/index.ts
@@ -107,6 +107,7 @@ const mercadoPagoService = new MercadoPagoService(
 
 const paymentOrderService = new PaymentOrderService(
 	paymentOrderRepository,
+	orderRepository,
 	orderService,
 	mercadoPagoService
 );

--- a/src/adapter/driver/schemas/orders.ts
+++ b/src/adapter/driver/schemas/orders.ts
@@ -12,6 +12,5 @@ export const updateOrderSchema = z
 	.object({
 		id: z.string(),
 		status: z.nativeEnum(OrderStatusEnum),
-		orderId: z.string(),
-	})
-	.required();
+		readableId: z.string().optional(),
+	});

--- a/src/core/application/ports/input/orders.ts
+++ b/src/core/application/ports/input/orders.ts
@@ -14,6 +14,6 @@ export type CreateOrderParams = {
 
 export type UpdateOrderParams = {
 	id?: string;
-	orderId?: string;
+	readableId?: string;
 	status?: OrderStatusType;
 };

--- a/src/core/application/services/orderService.ts
+++ b/src/core/application/services/orderService.ts
@@ -1,5 +1,5 @@
-import logger from '@common/logger';
 import { OrderStatusEnum } from '@application/enumerations/orderStatusEnum';
+import logger from '@common/logger';
 import { getOrderByIdSchema, updateOrderSchema } from '@driver/schemas/orders';
 import { InvalidOrderException } from '@exceptions/invalidOrderException';
 import { InvalidOrderStatusException } from '@exceptions/invalidOrderStatusException';


### PR DESCRIPTION
Foi alterada a tabela de order e inserido inicialmente o campo "orderId", entretanto, pensando na linguagem ubíquia, já usamos o campo orderId como sendo o id do pedido armazenado no banco. Com isso, alterei para "readableId".

A criação do campo ocorre na finalização do pagamento. É feita uma busca de quantos pedidos foram feitos no dia e possuem um id previamente cadastrado. Com o resultado se soma 1 e passa adiante para o updateOrder.